### PR TITLE
Fix syntax errors in AltimeterAutoHide.version

### DIFF
--- a/AltimeterAutoHide.version
+++ b/AltimeterAutoHide.version
@@ -2,7 +2,10 @@
     "NAME":"AltimeterAutoHide",
     "URL":"https://raw.githubusercontent.com/todi/AltimeterAutoHide/master/AltimeterAutoHide.version",
     "DOWNLOAD":"https://github.com/todi/AltimeterAutoHide/releases",
-    "GITHUB":
+    "GITHUB": {
+        "USERNAME": "todi",
+        "REPOSITORY": "AltimeterAutoHide"
+    },
     "VERSION":
     {
         "MAJOR":1,
@@ -21,5 +24,5 @@
         "MAJOR":1,
         "MINOR":8,
         "PATCH":0
-    },
+    }
 }


### PR DESCRIPTION
The newly added version file has two syntax errors:
The `GITHUB` property is missing a value, and there's an additional comma after `KSP_VERSION_MIN`.

You should also consider setting `KSP_VERSION_MAX`, because having the max version unlimited is generally discouraged for mods that include DLLs. DLLs tend to break every now and then, and with an unlimited compatibility you might get annoying reports from over-eager users.
Thanks to the `URL` property, you can always update the `KSP_VERSION_MAX` _after_ the release, for example if a new KSP version comes out and you determine that the current release still works fine. CKAN and AVC will both use the remote version file to update the compatibility information in retrospect.

I've also wrote a handy little tool that can catch the most common version file errors before they land in releases, if you want to give it a try:
https://github.com/DasSkelett/AVC-VersionFileValidator